### PR TITLE
CHORE: Issue Template aktualisiert und in .github verschoben

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Titel: ...
+
+- Wunschtermin: mmmm YYYY
+- Dauer: 
+	- [x] Regulär (30min)
+	- [ ] Lightning (15min)
+
+### Kurzbeschreibung
+
+// Um was geht es?
+
+
+### Publikum
+
+// Für wen ist dieser Talk besonders interessant?

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,0 @@
-## Titel: 
-
-- Dauer: 30 oder 15 Minuten
-- Wunschtermin: 
-
-Kurzbeschreibung: ... 


### PR DESCRIPTION
Eigentlich wollte ich nur eine neue Überschrift einführen, welche Speaker dazu auffordern soll, sich Gedanken über die Zielgruppe ihrer Talks zu machen. Zusätzlich habe ich noch ein wenig den Meta Teil überarbeitet um der üblichen Einteilung in Lightning / Reguläre Talks gerecht zu werden.