### PR TITLE
Fix tiny type at template-for-talk-proposals.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/template-for-talk-proposals.md
+++ b/.github/ISSUE_TEMPLATE/template-for-talk-proposals.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-# Titel: [e.g. Introduction to JavaScript]
+# Title: [e.g. Introduction to JavaScript]
 
 - Speaker: [e.g. Max Mustermann]
 - Affiliation: [Company you work at or None (optional)]


### PR DESCRIPTION
I noticed the issue template is kept in english, but `Titel` is still german